### PR TITLE
Add Set Operation Methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 
 /target
 
+# Dev files
+/dev
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 .pytest_cache/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use pyo3::prelude::*;
 
 use anyhow::{anyhow, Result};
 use log::debug;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 // use sourmash::sketch::nodegraph::Nodegraph;
 use sourmash::encodings::HashFunctions;
@@ -117,6 +117,45 @@ impl KmerCountTable {
         }
 
         Ok(n)
+    }
+
+    // Helper method to get hash set of k-mers
+    fn hash_set(&self) -> HashSet<u64> {
+        self.counts.keys().cloned().collect()
+    }
+
+    // Set operation methods
+    pub fn union(&self, other: &KmerCountTable) -> HashSet<u64> {
+        self.hash_set().union(&other.hash_set()).cloned().collect()
+    }
+
+    pub fn intersection(&self, other: &KmerCountTable) -> HashSet<u64> {
+        self.hash_set().intersection(&other.hash_set()).cloned().collect()
+    }
+
+    pub fn difference(&self, other: &KmerCountTable) -> HashSet<u64> {
+        self.hash_set().difference(&other.hash_set()).cloned().collect()
+    }
+
+    pub fn symmetric_difference(&self, other: &KmerCountTable) -> HashSet<u64> {
+        self.hash_set().symmetric_difference(&other.hash_set()).cloned().collect()
+    }
+
+    // Python dunder methods for set operations
+    fn __or__(&self, other: &KmerCountTable) -> HashSet<u64> {
+        self.union(other)
+    }
+
+    fn __and__(&self, other: &KmerCountTable) -> HashSet<u64> {
+        self.intersection(other)
+    }
+
+    fn __sub__(&self, other: &KmerCountTable) -> HashSet<u64> {
+        self.difference(other)
+    }
+
+    fn __xor__(&self, other: &KmerCountTable) -> HashSet<u64> {
+        self.symmetric_difference(other)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@ use pyo3::prelude::*;
 use sourmash::encodings::HashFunctions;
 use sourmash::signature::SeqToHashes;
 
-
 #[pyclass]
 struct KmerCountTable {
     counts: HashMap<u64, u64>,
@@ -144,15 +143,24 @@ impl KmerCountTable {
     }
 
     pub fn intersection(&self, other: &KmerCountTable) -> HashSet<u64> {
-        self.hash_set().intersection(&other.hash_set()).cloned().collect()
+        self.hash_set()
+            .intersection(&other.hash_set())
+            .cloned()
+            .collect()
     }
 
     pub fn difference(&self, other: &KmerCountTable) -> HashSet<u64> {
-        self.hash_set().difference(&other.hash_set()).cloned().collect()
+        self.hash_set()
+            .difference(&other.hash_set())
+            .cloned()
+            .collect()
     }
 
     pub fn symmetric_difference(&self, other: &KmerCountTable) -> HashSet<u64> {
-        self.hash_set().symmetric_difference(&other.hash_set()).cloned().collect()
+        self.hash_set()
+            .symmetric_difference(&other.hash_set())
+            .cloned()
+            .collect()
     }
 
     // Python dunder methods for set operations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,14 @@
-use pyo3::exceptions::PyValueError;
-use pyo3::prelude::*;
-// use rayon::prelude::*;
-
-use anyhow::{anyhow, Result};
-use log::debug;
+// Standard library imports
 use std::collections::{HashMap, HashSet};
 
-// use sourmash::sketch::nodegraph::Nodegraph;
+// External crate imports
+use anyhow::{anyhow, Result};
+use log::debug;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 use sourmash::encodings::HashFunctions;
 use sourmash::signature::SeqToHashes;
+
 
 #[pyclass]
 struct KmerCountTable {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ impl KmerCountTable {
         }
     }
 
-    // Consume this DNA strnig. Return number of k-mers consumed.
+    // Consume this DNA string. Return number of k-mers consumed.
     #[pyo3(signature = (seq, allow_bad_kmers=true))]
     pub fn consume(&mut self, seq: String, allow_bad_kmers: bool) -> PyResult<u64> {
         let hashes = SeqToHashes::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,18 @@ impl KmerCountTable {
         }
     }
 
+    // Get the count for a specific hash value directly
+    pub fn get_hash(&self, hashval: u64) -> u64 {
+        // Return the count for the hash value, or 0 if it does not exist
+        *self.counts.get(&hashval).unwrap_or(&0)
+    }
+
+    // Get counts for a list of hash keys and return an list of counts
+    pub fn get_hash_array(&self, hash_keys: Vec<u64>) -> Vec<u64> {
+        // Map each hash key to its count, defaulting to 0 if the key is not present
+        hash_keys.iter().map(|&key| self.get_hash(key)).collect()
+    }
+
     // Consume this DNA string. Return number of k-mers consumed.
     #[pyo3(signature = (seq, allow_bad_kmers=true))]
     pub fn consume(&mut self, seq: String, allow_bad_kmers: bool) -> PyResult<u64> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,13 @@ impl KmerCountTable {
         hash_keys.iter().map(|&key| self.get_hash(key)).collect()
     }
 
+    // Getter for the 'hashes' attribute, returning all hash keys in the table
+    #[getter]
+    pub fn hashes(&self) -> Vec<u64> {
+        // Collect and return all keys from the counts HashMap
+        self.counts.keys().cloned().collect()
+    }
+
     // Consume this DNA string. Return number of k-mers consumed.
     #[pyo3(signature = (seq, allow_bad_kmers=true))]
     pub fn consume(&mut self, seq: String, allow_bad_kmers: bool) -> PyResult<u64> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,14 +47,9 @@ impl KmerCountTable {
     }
 
     pub fn count_hash(&mut self, hashval: u64) -> u64 {
-        let mut count: u64 = 1;
-        if self.counts.contains_key(&hashval) {
-            count = *self.counts.get(&hashval).unwrap();
-            count = count + 1;
-        }
-        self.counts.insert(hashval, count);
-
-        count
+        let count = self.counts.entry(hashval).or_insert(0);
+        *count += 1;
+        *count
     }
 
     pub fn count(&mut self, kmer: String) -> PyResult<u64> {
@@ -159,6 +154,7 @@ impl KmerCountTable {
     }
 }
 
+// Python module definition
 #[pymodule]
 fn oxli(m: &Bound<'_, PyModule>) -> PyResult<()> {
     env_logger::init();

--- a/src/python/tests/test_basic.py
+++ b/src/python/tests/test_basic.py
@@ -1,6 +1,8 @@
-import pytest
 import oxli
+import pytest
 
+
+# Helper function, create tables.
 def create_sample_kmer_table(ksize, kmers):
     table = oxli.KmerCountTable(ksize)
     for kmer in kmers:
@@ -8,7 +10,8 @@ def create_sample_kmer_table(ksize, kmers):
     return table
 
 
-def test_simple():
+# Adding Kmers
+def test_count():
     # yo dawg it works
     cg = oxli.KmerCountTable(4)
     kmer = "ATCG"
@@ -16,6 +19,24 @@ def test_simple():
     assert cg.get(kmer) == 0
     assert cg.count(kmer) == 1
     assert cg.get(kmer) == 1
+
+
+def test_count_hash():
+    kmer = "TAAACCCTAACCCTAACCCTAACCCTAACCC"
+    cg = oxli.KmerCountTable(ksize=31)
+    hashkey = cg.hash_kmer(kmer)
+
+    assert cg.get_hash(hashkey) == 0
+    assert cg.count_hash(hashkey) == 1
+    assert cg.get_hash(hashkey) == 1
+
+
+def test_hash_rc():
+    table = create_sample_kmer_table(3, ["AAA", "TTT", "AAC"])
+    hash_aaa = table.hash_kmer("AAA")  # 10679328328772601858
+    hash_ttt = table.hash_kmer("TTT")  # 10679328328772601858
+
+    assert hash_aaa == hash_ttt, "Hash should be same for reverse complement."
 
 
 def test_wrong_ksize():
@@ -47,15 +68,14 @@ def test_consume_2():
     assert cg.consume(seq) == 2
     assert cg.get("ATCG") == 1
     assert cg.get("TCGG") == 1
-    assert cg.get("CCGA") == 1 # reverse complement!
+    assert cg.get("CCGA") == 1  # reverse complement!
 
 
 def test_consume_bad_DNA():
     # test an invalid base in last position
     cg = oxli.KmerCountTable(4)
     seq = "ATCGGX"
-    with pytest.raises(ValueError,
-                        match="bad k-mer encountered at position 2"):
+    with pytest.raises(ValueError, match="bad k-mer encountered at position 2"):
         cg.consume(seq, allow_bad_kmers=False)
 
 
@@ -63,8 +83,7 @@ def test_consume_bad_DNA_2():
     # test an invalid base in first position
     cg = oxli.KmerCountTable(4)
     seq = "XATCGG"
-    with pytest.raises(ValueError,
-                        match="bad k-mer encountered at position 0"):
+    with pytest.raises(ValueError, match="bad k-mer encountered at position 0"):
         cg.consume(seq, allow_bad_kmers=False)
 
 
@@ -75,7 +94,7 @@ def test_consume_bad_DNA_ignore():
     print(cg.consume(seq, allow_bad_kmers=True))
     assert cg.get("ATCG") == 1
     assert cg.get("TCGG") == 1
-    assert cg.get("CCGA") == 1 # rc
+    assert cg.get("CCGA") == 1  # rc
 
 
 def test_consume_bad_DNA_ignore_is_default():
@@ -85,104 +104,151 @@ def test_consume_bad_DNA_ignore_is_default():
     print(cg.consume(seq))
     assert cg.get("ATCG") == 1
     assert cg.get("TCGG") == 1
-    assert cg.get("CCGA") == 1 # rc
+    assert cg.get("CCGA") == 1  # rc
 
 
-def test_count_get():
+# Test attributes
+def test_hashes_attribute():
+    table = create_sample_kmer_table(3, ["AAA", "TTT", "AAC"])
+    hashes = table.hashes
+    hash_aaa = table.hash_kmer("AAA")  # 10679328328772601858
+    hash_ttt = table.hash_kmer("TTT")  # 10679328328772601858
+    hash_aac = table.hash_kmer("AAC")  # 6579496673972597301
+
+    expected_hashes = set(
+        [hash_aaa, hash_ttt, hash_aac]
+    )  # {10679328328772601858, 6579496673972597301}
+    assert (
+        set(hashes) == expected_hashes
+    ), ".hashes attribute should match the expected set of hash keys"
+
+
+# Getting counts
+def test_count_vs_counthash():
     # test a bug reported by adam taranto: count and get should work together!
-    kmer = 'TAAACCCTAACCCTAACCCTAACCCTAACCC'
-
+    kmer = "TAAACCCTAACCCTAACCCTAACCCTAACCC"
     cg = oxli.KmerCountTable(ksize=31)
     hashkey = cg.hash_kmer(kmer)
 
     assert cg.get(kmer) == 0
     assert cg.count(kmer) == 1
     assert cg.count(kmer) == 2
+    assert cg.get(kmer) == 2
+    assert cg.count_hash(hashkey) == 3
 
     x = cg.get(kmer)
-    assert x == 2, x
-    
+    assert x == 3, x
+
 
 def test_get_hash():
-    ''' Retrieve counts using hash key. '''
-    table = create_sample_kmer_table(3, ['AAA', 'TTT', 'AAC'])
+    """Retrieve counts using hash key."""
+    table = create_sample_kmer_table(3, ["AAA", "TTT", "AAC"])
     # Find hash of kmer 'AAA'
-    hash_aaa = table.hash_kmer('AAA') # 10679328328772601858
+    hash_aaa = table.hash_kmer("AAA")  # 10679328328772601858
     # Lookup counts for hash of 'AAA' and rc 'TTT'
     count_aaa = table.get_hash(hash_aaa)
-    
     assert count_aaa == 2, "Hash count for 'AAA' should be 2"
 
-    hash_aac = table.hash_kmer('AAC') # 6579496673972597301
+    # Test single kmer
+    hash_aac = table.hash_kmer("AAC")  # 6579496673972597301
     count_aac = table.get_hash(hash_aac)
-    
     assert count_aac == 1, "Hash count for 'AAC' should be 1"
 
-def test_get_hash_array():
-    ''' 
-    Get vector of counts corresponding to vector of hash keys.
-    '''
-    table = create_sample_kmer_table(3, ['AAA', 'AAC'])
-    hash_aaa = table.hash_kmer('AAA')
-    hash_aac = table.hash_kmer('AAC')
-    hash_ggg = table.hash_kmer('GGG') # key not in table
-    
-    hash_keys = [hash_aaa, hash_aac, hash_ggg]
-    counts = table.get_hash_array(hash_keys)
-    
-    assert counts == [1, 1, 0], "Hash array counts should match the counts of 'AAA' and 'AAC' and return zero for 'GGG'."
+    # Test for kmer that is not in table
+    hash_aag = table.hash_kmer("AAG")  # 12774992397053849803
+    count_aag = table.get_hash(hash_aag)
+    assert count_aag == 0, "Missing kmer count for 'AAG' should be 0"
 
+
+def test_get_hash_array():
+    """
+    Get vector of counts corresponding to vector of hash keys.
+    """
+    table = create_sample_kmer_table(3, ["AAA", "TTT", "AAC"])
+    hash_aaa = table.hash_kmer("AAA")
+    hash_aac = table.hash_kmer("AAC")
+    hash_ggg = table.hash_kmer("GGG")  # key not in table
+
+    hash_keys = [hash_aaa, hash_aac, hash_ggg]
+    hash_keys_rev = [hash_ggg, hash_aac, hash_aaa]
+
+    counts = table.get_hash_array(hash_keys)
+    rev_counts = table.get_hash_array(hash_keys_rev)
+
+    assert (
+        counts == [2, 1, 0]
+    ), "Hash array counts should match the counts of 'AAA' and 'AAC' and return zero for 'GGG'."
+    assert rev_counts == [0, 1, 2], "Count should be in same order as input list"
+
+
+def test_get_array():
+    """
+    Get vector of counts corresponding to vector of kmers.
+    """
+    # TODO: Add function to get list of counts given list of kmers.
+    pass
+
+
+# Set operations
 def test_union():
-    table1 = create_sample_kmer_table(3, ['AAA', 'AAC'])
-    table2 = create_sample_kmer_table(3, ['AAC', 'AAG'])
-    
+    table1 = create_sample_kmer_table(3, ["AAA", "AAC"])
+    table2 = create_sample_kmer_table(3, ["AAC", "AAG"])
+
     union_set = table1.union(table2)
     expected_union = set(table1.hashes).union(table2.hashes)
-    
+
     assert union_set == expected_union, "Union of hash sets should match"
 
+
 def test_intersection():
-    table1 = create_sample_kmer_table(3, ['AAA', 'AAC'])
-    table2 = create_sample_kmer_table(3, ['AAC', 'AAG'])
-    
+    table1 = create_sample_kmer_table(3, ["AAA", "AAC"])
+    table2 = create_sample_kmer_table(3, ["AAC", "AAG"])
+
     intersection_set = table1.intersection(table2)
     expected_intersection = set(table1.hashes).intersection(table2.hashes)
-    
-    assert intersection_set == expected_intersection, "Intersection of hash sets should match"
+
+    assert (
+        intersection_set == expected_intersection
+    ), "Intersection of hash sets should match"
+
 
 def test_difference():
-    table1 = create_sample_kmer_table(3, ['AAA', 'AAC'])
-    table2 = create_sample_kmer_table(3, ['AAC', 'AAG'])
-    
+    table1 = create_sample_kmer_table(3, ["AAA", "AAC"])
+    table2 = create_sample_kmer_table(3, ["AAC", "AAG"])
+
     difference_set = table1.difference(table2)
     expected_difference = set(table1.hashes).difference(table2.hashes)
-    
+
     assert difference_set == expected_difference, "Difference of hash sets should match"
 
+
 def test_symmetric_difference():
-    table1 = create_sample_kmer_table(3, ['AAA', 'AAC'])
-    table2 = create_sample_kmer_table(3, ['AAC', 'AAG'])
-    
+    table1 = create_sample_kmer_table(3, ["AAA", "AAC"])
+    table2 = create_sample_kmer_table(3, ["AAC", "AAG"])
+
     symmetric_difference_set = table1.symmetric_difference(table2)
-    expected_symmetric_difference = set(table1.hashes).symmetric_difference(table2.hashes)
-    
-    assert symmetric_difference_set == expected_symmetric_difference, "Symmetric difference of hash sets should match"
+    expected_symmetric_difference = set(table1.hashes).symmetric_difference(
+        table2.hashes
+    )
+
+    assert (
+        symmetric_difference_set == expected_symmetric_difference
+    ), "Symmetric difference of hash sets should match"
+
 
 def test_dunder_methods():
-    table1 = create_sample_kmer_table(3, ['AAA', 'AAC'])
-    table2 = create_sample_kmer_table(3, ['AAC', 'AAG'])
-    
-    assert table1.__or__(table2) == table1.union(table2), "__or__ method should match union()"
-    assert table1.__and__(table2) == table1.intersection(table2), "__and__ method should match intersection()"
-    assert table1.__sub__(table2) == table1.difference(table2), "__sub__ method should match difference()"
-    assert table1.__xor__(table2) == table1.symmetric_difference(table2), "__xor__ method should match symmetric_difference()"
+    table1 = create_sample_kmer_table(3, ["AAA", "AAC"])
+    table2 = create_sample_kmer_table(3, ["AAC", "AAG"])
 
-def test_hashes_attribute():
-    table = create_sample_kmer_table(3, ['AAA', 'TTT', 'AAC'])
-    hashes = table.hashes
-    hash_aaa = table.hash_kmer('AAA') #10679328328772601858
-    hash_ttt = table.hash_kmer('TTT') #10679328328772601858
-    hash_aac = table.hash_kmer('AAC') #6579496673972597301
-    
-    expected_hashes = set([hash_aaa, hash_ttt, hash_aac]) #{10679328328772601858, 6579496673972597301}
-    assert set(hashes) == expected_hashes, ".hashes attribute should match the expected set of hash keys"
+    assert table1.__or__(table2) == table1.union(
+        table2
+    ), "__or__ method should match union()"
+    assert table1.__and__(table2) == table1.intersection(
+        table2
+    ), "__and__ method should match intersection()"
+    assert table1.__sub__(table2) == table1.difference(
+        table2
+    ), "__sub__ method should match difference()"
+    assert table1.__xor__(table2) == table1.symmetric_difference(
+        table2
+    ), "__xor__ method should match symmetric_difference()"

--- a/src/python/tests/test_basic.py
+++ b/src/python/tests/test_basic.py
@@ -1,6 +1,13 @@
 import pytest
 import oxli
 
+def create_sample_kmer_table(ksize, kmers):
+    table = oxli.KmerCountTable(ksize)
+    for kmer in kmers:
+        table.count(kmer)
+    return table
+
+
 def test_simple():
     # yo dawg it works
     cg = oxli.KmerCountTable(4)
@@ -48,7 +55,7 @@ def test_consume_bad_DNA():
     cg = oxli.KmerCountTable(4)
     seq = "ATCGGX"
     with pytest.raises(ValueError,
-                       match="bad k-mer encountered at position 2"):
+                        match="bad k-mer encountered at position 2"):
         cg.consume(seq, allow_bad_kmers=False)
 
 
@@ -57,7 +64,7 @@ def test_consume_bad_DNA_2():
     cg = oxli.KmerCountTable(4)
     seq = "XATCGG"
     with pytest.raises(ValueError,
-                       match="bad k-mer encountered at position 0"):
+                        match="bad k-mer encountered at position 0"):
         cg.consume(seq, allow_bad_kmers=False)
 
 
@@ -95,3 +102,87 @@ def test_count_get():
     x = cg.get(kmer)
     assert x == 2, x
     
+
+def test_get_hash():
+    ''' Retrieve counts using hash key. '''
+    table = create_sample_kmer_table(3, ['AAA', 'TTT', 'AAC'])
+    # Find hash of kmer 'AAA'
+    hash_aaa = table.hash_kmer('AAA') # 10679328328772601858
+    # Lookup counts for hash of 'AAA' and rc 'TTT'
+    count_aaa = table.get_hash(hash_aaa)
+    
+    assert count_aaa == 2, "Hash count for 'AAA' should be 2"
+
+    hash_aac = table.hash_kmer('AAC') # 6579496673972597301
+    count_aac = table.get_hash(hash_aac)
+    
+    assert count_aac == 1, "Hash count for 'AAC' should be 1"
+
+def test_get_hash_array():
+    ''' 
+    Get vector of counts corresponding to vector of hash keys.
+    '''
+    table = create_sample_kmer_table(3, ['AAA', 'AAC'])
+    hash_aaa = table.hash_kmer('AAA')
+    hash_aac = table.hash_kmer('AAC')
+    hash_ggg = table.hash_kmer('GGG') # key not in table
+    
+    hash_keys = [hash_aaa, hash_aac, hash_ggg]
+    counts = table.get_hash_array(hash_keys)
+    
+    assert counts == [1, 1, 0], "Hash array counts should match the counts of 'AAA' and 'AAC' and return zero for 'GGG'."
+
+def test_union():
+    table1 = create_sample_kmer_table(3, ['AAA', 'AAC'])
+    table2 = create_sample_kmer_table(3, ['AAC', 'AAG'])
+    
+    union_set = table1.union(table2)
+    expected_union = set(table1.hashes).union(table2.hashes)
+    
+    assert union_set == expected_union, "Union of hash sets should match"
+
+def test_intersection():
+    table1 = create_sample_kmer_table(3, ['AAA', 'AAC'])
+    table2 = create_sample_kmer_table(3, ['AAC', 'AAG'])
+    
+    intersection_set = table1.intersection(table2)
+    expected_intersection = set(table1.hashes).intersection(table2.hashes)
+    
+    assert intersection_set == expected_intersection, "Intersection of hash sets should match"
+
+def test_difference():
+    table1 = create_sample_kmer_table(3, ['AAA', 'AAC'])
+    table2 = create_sample_kmer_table(3, ['AAC', 'AAG'])
+    
+    difference_set = table1.difference(table2)
+    expected_difference = set(table1.hashes).difference(table2.hashes)
+    
+    assert difference_set == expected_difference, "Difference of hash sets should match"
+
+def test_symmetric_difference():
+    table1 = create_sample_kmer_table(3, ['AAA', 'AAC'])
+    table2 = create_sample_kmer_table(3, ['AAC', 'AAG'])
+    
+    symmetric_difference_set = table1.symmetric_difference(table2)
+    expected_symmetric_difference = set(table1.hashes).symmetric_difference(table2.hashes)
+    
+    assert symmetric_difference_set == expected_symmetric_difference, "Symmetric difference of hash sets should match"
+
+def test_dunder_methods():
+    table1 = create_sample_kmer_table(3, ['AAA', 'AAC'])
+    table2 = create_sample_kmer_table(3, ['AAC', 'AAG'])
+    
+    assert table1.__or__(table2) == table1.union(table2), "__or__ method should match union()"
+    assert table1.__and__(table2) == table1.intersection(table2), "__and__ method should match intersection()"
+    assert table1.__sub__(table2) == table1.difference(table2), "__sub__ method should match difference()"
+    assert table1.__xor__(table2) == table1.symmetric_difference(table2), "__xor__ method should match symmetric_difference()"
+
+def test_hashes_attribute():
+    table = create_sample_kmer_table(3, ['AAA', 'TTT', 'AAC'])
+    hashes = table.hashes
+    hash_aaa = table.hash_kmer('AAA') #10679328328772601858
+    hash_ttt = table.hash_kmer('TTT') #10679328328772601858
+    hash_aac = table.hash_kmer('AAC') #6579496673972597301
+    
+    expected_hashes = set([hash_aaa, hash_ttt, hash_aac]) #{10679328328772601858, 6579496673972597301}
+    assert set(hashes) == expected_hashes, ".hashes attribute should match the expected set of hash keys"


### PR DESCRIPTION
I've added support for set operations on KmerHashTable objects. 

I'm very new to Rust, but the test cases I've written are passing. Review with caution!

Summary of changes:

- Simplified `count_hash()` method so only does one hashmap lookup
- Add `get_hash()` to query kmer counts using hash key. Returns zero if missing key.
- Add `get_hash_array()` to lookup many hash keys at once, takes list of keys, returns list of values. Returns zero for missing keys.
- Add `.hashes` attribute as per sourmash, returns list of all keys in table
- Add set operation methods:

```python
# Perform set operations on the KmerHashTable objects
union_hashes = kmer_table1.union(kmer_table2)
intersection_hashes = kmer_table1.intersection(kmer_table2)
difference_hashes = kmer_table1.difference(kmer_table2)
symmetric_difference_hashes = kmer_table1.symmetric_difference(kmer_table2)
```

- Add dunder methods to do set operations directly on KmerHashTable objects
```python
union_hashes = kmer_table1 | kmer_table2          # Union
intersection_hashes = kmer_table1 & kmer_table2   # Intersection
difference_hashes = kmer_table1 - kmer_table2     # Difference
symmetric_difference_hashes = kmer_table1 ^ kmer_table2 # Symmetric Difference
```

