### PR TITLE
MRG: some suggested changes for new dunder methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "approx"
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831e8e819a138c36e212f3af3fd9eeffed6bf1510a805af35b0edee5ffa59433"
+checksum = "15ee168e30649f7f234c3d49ef5a7a6cbf5134289bc46c29ff3155fa3221c225"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -777,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8730e591b14492a8945cdff32f089250b05f5accecf74aeddf9e8272ce1fa8"
+checksum = "e61cef80755fe9e46bb8a0b8f20752ca7676dcc07a5277d8b7768c6172e529b3"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -787,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e97e919d2df92eb88ca80a037969f44e5e70356559654962cbb3316d00300c6"
+checksum = "67ce096073ec5405f5ee2b8b31f03a68e02aa10d5d4f565eca04acc41931fa1c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb57983022ad41f9e683a599f2fd13c3664d7063a3ac5714cae4b7bee7d3f206"
+checksum = "2440c6d12bc8f3ae39f1e775266fa5122fd0c8891ce7520fa6048e683ad3de28"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -809,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec480c0c51ddec81019531705acac51bcdbeae563557c982aa8263bb96880372"
+checksum = "1be962f0e06da8f8465729ea2cb71a416d2257dff56cbe40a70d3e62a93ae5d1"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ name = "oxli"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version="0.22.2", features = ["extension-module", "anyhow"] }
+pyo3 = { version="0.22.3", features = ["extension-module", "anyhow"] }
 sourmash = "0.15.1"
-anyhow = "1.0.87"
+anyhow = "1.0.89"
 log = "0.4.22"
 env_logger = "0.11.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 // Standard library imports
 use std::collections::{HashMap, HashSet};
+use std::collections::hash_map::IntoIter;
 
 // External crate imports
 use anyhow::{anyhow, Result};
@@ -70,10 +71,9 @@ impl KmerCountTable {
                 "kmer size does not match count table ksize",
             ))
         } else {
-            let hashval = self.hash_kmer(kmer.clone()).unwrap();
-            let count = self.count_hash(hashval);
-            // Update the total sequence length tracker
             self.consumed += kmer.len() as u64;
+            let hashval = self.hash_kmer(kmer)?;
+            let count = self.count_hash(hashval);
             Ok(count)
         }
     }
@@ -275,7 +275,7 @@ impl KmerCountTable {
 // Iterator implementation for KmerCountTable
 #[pyclass]
 pub struct KmerCountTableIterator {
-    inner: std::collections::hash_map::IntoIter<u64, u64>, // Now we own the iterator
+    inner: IntoIter<u64, u64>, // Now we own the iterator
 }
 
 #[pymethods]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 // Standard library imports
-use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::IntoIter;
+use std::collections::{HashMap, HashSet};
 
 // External crate imports
 use anyhow::{anyhow, Result};


### PR DESCRIPTION
NOTE: PR into #27

This PR:
- merges in latest main
- moves the hashmap IntoIter import into the top;
- removes an unnecessary clone;
- propagates errors (probably unnecessarily ;)) from `hash_kmer` in `count`;